### PR TITLE
use zmq with version (0)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "ext-zmq": "^1.1"
+        "ext-zmq": "=0|^1.1"
     },
     "require-dev": {
         "laravel/laravel": "4.2.*"


### PR DESCRIPTION
[php-zmq](https://pecl.php.net/package/zmq) is not maintained anymore from PECL 
we should compile it by ourselves with the official [php-zmq](https://github.com/zeromq/php-zmq) package
as already been used in [buyme-v2](https://github.com/buymetech/buyme-v2/blob/main/docker/Dockerfile#L75-L81).
the problem is that version control is not working anymore so we need to accept also version ``0`` (as int without 0.5)
or forced version in some way in the compile process.

as we  can see when we are doing ``composer install``
```bash
buyme/proc-lock-client dev-master requires ext-zmq ^1.1 -> it has the wrong version installed (0).
```

for that, we should use
 ```json
    "require": {
        "ext-zmq": "=0|^1.1"
    }
```

for Linux like Debian they already have [a solution](https://metadata.ftp-master.debian.org/changelogs//main/p/php-zmq/php-zmq_1.1.3-24_changelog). this PR is regarding to local environment only  